### PR TITLE
Implement configurable platform + tenant onboarding builder

### DIFF
--- a/backend/routes/adminRoutes.js
+++ b/backend/routes/adminRoutes.js
@@ -282,6 +282,12 @@ router.get('/admin/user/:userId/analytics', verifyToken, requireAdmin, async (re
 });
 
 const getGlobalModels = require('../services/getGlobalModelService');
+const {
+  SIGNUP_OPTIONS,
+  TENANT_TEMPLATE_LIBRARY,
+  sanitizePlatformOnboardingConfig,
+  getPlatformOnboardingConfig,
+} = require('../services/onboardingConfigService');
 
 /**
  * GET /admin/platform-admins – list platform admins (GlobalUsers with platform_admin role)
@@ -508,6 +514,71 @@ router.put('/admin/tenant-config', verifyToken, requireAdmin, async (req, res) =
     });
   } catch (err) {
     console.error('PUT /admin/tenant-config failed:', err);
+    res.status(500).json({ success: false, message: err.message });
+  }
+});
+
+router.get('/admin/platform-onboarding-config', verifyToken, requireAdmin, async (req, res) => {
+  if (!req.user.platformRoles?.includes('platform_admin')) {
+    return res.status(403).json({ success: false, message: 'Platform admin required.' });
+  }
+  try {
+    const { TenantConfig } = getGlobalModels(req, 'TenantConfig');
+    const doc = await TenantConfig.findOne({ configKey: 'default' }).lean();
+    const config = getPlatformOnboardingConfig(doc?.onboardingConfig || null);
+    res.json({
+      success: true,
+      data: {
+        config,
+        meta: {
+          signupOptions: SIGNUP_OPTIONS,
+        },
+      },
+    });
+  } catch (err) {
+    console.error('GET /admin/platform-onboarding-config failed:', err);
+    res.status(500).json({ success: false, message: err.message });
+  }
+});
+
+router.put('/admin/platform-onboarding-config', verifyToken, requireAdmin, async (req, res) => {
+  if (!req.user.platformRoles?.includes('platform_admin')) {
+    return res.status(403).json({ success: false, message: 'Platform admin required.' });
+  }
+  try {
+    const incoming = req.body?.config;
+    if (!incoming || typeof incoming !== 'object') {
+      return res.status(400).json({ success: false, message: 'config object is required.' });
+    }
+    const config = sanitizePlatformOnboardingConfig(incoming);
+    const { TenantConfig } = getGlobalModels(req, 'TenantConfig');
+    const updatedBy = req.user.globalUserId || req.user.userId || null;
+    const doc = await TenantConfig.findOneAndUpdate(
+      { configKey: 'default' },
+      { $set: { onboardingConfig: config, updatedBy } },
+      { new: true, upsert: true, setDefaultsOnInsert: true }
+    ).lean();
+    res.json({
+      success: true,
+      data: {
+        config: getPlatformOnboardingConfig(doc?.onboardingConfig || null),
+        updatedAt: doc?.updatedAt || null,
+      },
+    });
+  } catch (err) {
+    console.error('PUT /admin/platform-onboarding-config failed:', err);
+    res.status(500).json({ success: false, message: err.message });
+  }
+});
+
+router.get('/admin/tenant-onboarding-template-library', verifyToken, requireAdmin, async (req, res) => {
+  try {
+    res.json({
+      success: true,
+      data: TENANT_TEMPLATE_LIBRARY,
+    });
+  } catch (err) {
+    console.error('GET /admin/tenant-onboarding-template-library failed:', err);
     res.status(500).json({ success: false, message: err.message });
   }
 });

--- a/backend/routes/userRoutes.js
+++ b/backend/routes/userRoutes.js
@@ -1,6 +1,8 @@
 const express = require('express');
 const { verifyToken, verifyTokenOptional, authorizeRoles } = require('../middlewares/verifyToken');
 const { requireAdmin } = require('../middlewares/requireAdmin');
+const getGlobalModels = require('../services/getGlobalModelService');
+const mongoose = require('mongoose');
 const cron = require('node-cron');
 const axios = require('axios');
 const { isProfane } = require('../services/profanityFilterService');
@@ -13,6 +15,13 @@ const { uploadImageToS3, deleteAndUploadImageToS3 } = require('../services/image
 const { sendRoomCheckinEvent } = require('../inngest/events');
 const multer = require('multer');
 const path = require('path');
+const {
+    sanitizeTenantOnboardingConfig,
+    getPlatformOnboardingConfig,
+    detectSignupOption,
+    resolveOnboardingSteps,
+    TENANT_TEMPLATE_LIBRARY,
+} = require('../services/onboardingConfigService');
 
 const upload = multer({
     storage: multer.memoryStorage(),
@@ -23,6 +32,371 @@ const upload = multer({
 
 
 const router = express.Router();
+
+async function loadResolvedOnboardingConfig(req, user) {
+    const { TenantConfig } = getGlobalModels(req, 'TenantConfig');
+    const { TenantOnboardingConfig } = getModels(req, 'TenantOnboardingConfig');
+    const [platformDoc, tenantDoc] = await Promise.all([
+        TenantConfig.findOne({ configKey: 'default' }).lean(),
+        TenantOnboardingConfig.findOne({ configKey: 'default' }).lean(),
+    ]);
+    const platformConfig = getPlatformOnboardingConfig(platformDoc?.onboardingConfig || null);
+    const tenantConfig = sanitizeTenantOnboardingConfig(tenantDoc || null);
+    const signupOption = detectSignupOption(user);
+    const steps = resolveOnboardingSteps(platformConfig, tenantConfig, signupOption);
+    return {
+        steps,
+        signupOption,
+        tenantConfig,
+        platformConfig,
+    };
+}
+
+async function applyOnboardingTemplateEffects(req, userId, templateSelections = {}) {
+    const normalized = templateSelections && typeof templateSelections === 'object' ? templateSelections : {};
+    const selectedOrgIds = Array.isArray(normalized.follow_orgs) ? normalized.follow_orgs : [];
+    const selectedFriendUserIds = Array.isArray(normalized.add_friends) ? normalized.add_friends : [];
+    const validOrgIds = selectedOrgIds.filter((id) => mongoose.Types.ObjectId.isValid(id));
+    const validFriendIdsInput = selectedFriendUserIds.filter((id) => mongoose.Types.ObjectId.isValid(id));
+
+    if (validOrgIds.length > 0) {
+        const { Org, OrgFollower } = getModels(req, 'Org', 'OrgFollower');
+        const existing = await OrgFollower.find({
+            user_id: userId,
+            org_id: { $in: validOrgIds },
+        }).select('org_id').lean();
+        const existingSet = new Set(existing.map((row) => String(row.org_id)));
+        const validOrgDocs = await Org.find({ _id: { $in: validOrgIds } }).select('_id').lean();
+        const followersToCreate = validOrgDocs
+            .map((org) => String(org._id))
+            .filter((orgId) => !existingSet.has(orgId))
+            .map((orgId) => ({
+                user_id: userId,
+                org_id: orgId,
+            }));
+        if (followersToCreate.length > 0) {
+            await OrgFollower.insertMany(followersToCreate, { ordered: false });
+        }
+    }
+
+    if (validFriendIdsInput.length > 0) {
+        const { User, Friendship } = getModels(req, 'User', 'Friendship');
+        const candidateUsers = await User.find({
+            _id: { $in: validFriendIdsInput },
+        }).select('_id').lean();
+        const validFriendIds = candidateUsers
+            .map((u) => String(u._id))
+            .filter((id) => id !== String(userId));
+        if (validFriendIds.length > 0) {
+            const existing = await Friendship.find({
+                $or: [
+                    { requester: userId, recipient: { $in: validFriendIds } },
+                    { requester: { $in: validFriendIds }, recipient: userId },
+                ],
+            }).select('requester recipient').lean();
+            const existingPairs = new Set(
+                existing.map((row) => [String(row.requester), String(row.recipient)].sort().join(':'))
+            );
+            const friendshipDocs = validFriendIds
+                .filter((friendId) => !existingPairs.has([String(userId), friendId].sort().join(':')))
+                .map((friendId) => ({
+                    requester: userId,
+                    recipient: friendId,
+                    status: 'pending',
+                }));
+            if (friendshipDocs.length > 0) {
+                await Friendship.insertMany(friendshipDocs, { ordered: false });
+            }
+        }
+    }
+}
+
+function parseOnboardingResponses(rawResponses) {
+    if (!rawResponses) return {};
+    if (typeof rawResponses === 'object') return rawResponses;
+    try {
+        const parsed = JSON.parse(rawResponses);
+        return parsed && typeof parsed === 'object' ? parsed : {};
+    } catch (_error) {
+        return {};
+    }
+}
+
+function validateStepResponse(step, value) {
+    const isEmpty = value == null || value === '' || (Array.isArray(value) && value.length === 0);
+    if (step.required && isEmpty) {
+        return { valid: false, message: `Step "${step.title}" is required.` };
+    }
+    if (isEmpty) {
+        return { valid: true };
+    }
+
+    if (step.type === 'short_text' || step.type === 'long_text') {
+        if (typeof value !== 'string') {
+            return { valid: false, message: `Step "${step.title}" must be text.` };
+        }
+    }
+
+    if (step.type === 'number') {
+        const n = Number(value);
+        if (!Number.isFinite(n)) {
+            return { valid: false, message: `Step "${step.title}" must be a number.` };
+        }
+    }
+
+    if (step.type === 'single_select') {
+        const validValues = new Set((step.options || []).map((option) => option.value));
+        if (typeof value !== 'string' || !validValues.has(value)) {
+            return { valid: false, message: `Step "${step.title}" has an invalid selection.` };
+        }
+    }
+
+    if (step.type === 'multi_select') {
+        const validValues = new Set((step.options || []).map((option) => option.value));
+        if (!Array.isArray(value) || value.some((entry) => !validValues.has(entry))) {
+            return { valid: false, message: `Step "${step.title}" has invalid selections.` };
+        }
+        if (step.maxSelections && value.length > step.maxSelections) {
+            return { valid: false, message: `Step "${step.title}" exceeds max selections.` };
+        }
+    }
+
+    if (step.type === 'template_follow_orgs' || step.type === 'template_add_friends') {
+        if (!Array.isArray(value)) {
+            return { valid: false, message: `Step "${step.title}" must be a list.` };
+        }
+    }
+
+    return { valid: true };
+}
+
+router.get('/onboarding-config', verifyToken, async (req, res) => {
+    const { User } = getModels(req, 'User');
+    try {
+        const user = await User.findById(req.user.userId).lean();
+        if (!user) {
+            return res.status(404).json({ success: false, message: 'User not found' });
+        }
+        const resolved = await loadResolvedOnboardingConfig(req, user);
+        return res.json({
+            success: true,
+            data: {
+                steps: resolved.steps,
+                signupOption: resolved.signupOption,
+                templateLibrary: TENANT_TEMPLATE_LIBRARY,
+            },
+        });
+    } catch (error) {
+        console.error('GET /onboarding-config failed', error);
+        return res.status(500).json({ success: false, message: error.message });
+    }
+});
+
+router.get('/onboarding-profile', verifyToken, async (req, res) => {
+    const { User, Org, OrgFollower, Friendship } = getModels(req, 'User', 'Org', 'OrgFollower', 'Friendship');
+    const type = String(req.query.type || '').trim().toLowerCase();
+    const query = String(req.query.query || '').trim();
+    const limit = Math.min(Math.max(parseInt(req.query.limit, 10) || 12, 1), 30);
+    try {
+        if (type === 'orgs') {
+            const regex = query ? new RegExp(query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i') : null;
+            const orgQuery = regex ? { org_name: regex } : {};
+            const orgs = await Org.find(orgQuery)
+                .select('_id org_name org_profile_image org_description')
+                .limit(limit)
+                .lean();
+            const followed = await OrgFollower.find({
+                user_id: req.user.userId,
+                org_id: { $in: orgs.map((org) => org._id) },
+            }).select('org_id').lean();
+            const followedSet = new Set(followed.map((row) => String(row.org_id)));
+            return res.json({
+                success: true,
+                data: orgs.map((org) => ({
+                    _id: org._id,
+                    name: org.org_name,
+                    description: org.org_description,
+                    picture: org.org_profile_image,
+                    isFollowing: followedSet.has(String(org._id)),
+                })),
+            });
+        }
+
+        if (type === 'users') {
+            const userQuery = { _id: { $ne: req.user.userId } };
+            if (query) {
+                const regex = new RegExp(query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i');
+                userQuery.$or = [{ username: regex }, { name: regex }];
+            }
+            const users = await User.find(userQuery)
+                .select('_id username name picture')
+                .limit(limit)
+                .lean();
+            const friendships = await Friendship.find({
+                $or: [
+                    { requester: req.user.userId, recipient: { $in: users.map((u) => u._id) } },
+                    { requester: { $in: users.map((u) => u._id) }, recipient: req.user.userId },
+                ],
+            }).select('requester recipient status').lean();
+            const relationMap = new Map();
+            friendships.forEach((row) => {
+                const other = String(row.requester) === String(req.user.userId) ? String(row.recipient) : String(row.requester);
+                let status = row.status || 'pending';
+                if (status === 'pending' && String(row.requester) !== String(req.user.userId)) {
+                    status = 'pending_inbound';
+                } else if (status === 'pending') {
+                    status = 'pending_outbound';
+                }
+                relationMap.set(other, status);
+            });
+            return res.json({
+                success: true,
+                data: users.map((u) => ({
+                    _id: u._id,
+                    username: u.username,
+                    name: u.name,
+                    picture: u.picture,
+                    friendshipStatus: relationMap.get(String(u._id)) || 'none',
+                })),
+            });
+        }
+
+        return res.status(400).json({ success: false, message: 'type must be "orgs" or "users".' });
+    } catch (error) {
+        console.error('GET /onboarding-profile failed', error);
+        return res.status(500).json({ success: false, message: error.message });
+    }
+});
+
+router.post('/submit-onboarding', verifyToken, upload.single('picture'), async (req, res) => {
+    const { User } = getModels(req, 'User');
+    try {
+        const user = await User.findById(req.user.userId);
+        if (!user) {
+            return res.status(404).json({ success: false, message: 'User not found' });
+        }
+        const responses = parseOnboardingResponses(req.body?.responses);
+        const resolved = await loadResolvedOnboardingConfig(req, user);
+        const errors = [];
+        const normalizedResponses = {};
+        const templateSelections = {};
+
+        resolved.steps.forEach((step) => {
+            const value = responses[step.key];
+            const validation = validateStepResponse(step, value);
+            if (!validation.valid) {
+                errors.push(validation.message);
+                return;
+            }
+            if (value == null || value === '' || (Array.isArray(value) && value.length === 0)) {
+                return;
+            }
+            if (step.type === 'number') {
+                normalizedResponses[step.key] = Number(value);
+            } else {
+                normalizedResponses[step.key] = value;
+            }
+            if (step.type === 'template_follow_orgs' || step.type === 'template_add_friends') {
+                templateSelections[step.templateKey] = Array.isArray(value) ? value : [];
+            }
+        });
+
+        if (errors.length > 0) {
+            return res.status(400).json({
+                success: false,
+                message: 'Onboarding submission has validation errors.',
+                errors,
+            });
+        }
+
+        const hasNameResponse = Object.prototype.hasOwnProperty.call(normalizedResponses, 'name');
+        if (hasNameResponse && typeof normalizedResponses.name === 'string' && normalizedResponses.name.trim()) {
+            user.name = normalizedResponses.name.trim();
+        }
+
+        const hasUsernameResponse = Object.prototype.hasOwnProperty.call(normalizedResponses, 'username');
+        if (hasUsernameResponse && typeof normalizedResponses.username === 'string' && normalizedResponses.username.trim()) {
+            user.username = normalizedResponses.username.trim();
+        }
+
+        if (req.file) {
+            const fileExtension = path.extname(req.file.originalname || '.png');
+            const timestamp = Date.now();
+            const fileName = `${req.user.userId}-${timestamp}${fileExtension}`;
+            if (user.picture) {
+                user.picture = await deleteAndUploadImageToS3(req.file, 'users', user.picture, fileName);
+            } else {
+                user.picture = await uploadImageToS3(req.file, 'users', fileName);
+            }
+        }
+
+        user.onboardingResponses = normalizedResponses;
+        user.onboarded = true;
+        user.onboardingCompletedAt = new Date();
+
+        await applyOnboardingTemplateEffects(req, req.user.userId, templateSelections);
+        await user.save();
+
+        return res.status(200).json({
+            success: true,
+            message: 'Onboarding completed successfully.',
+            data: {
+                onboarded: true,
+                onboardingResponses: normalizedResponses,
+                picture: user.picture || null,
+            },
+        });
+    } catch (error) {
+        console.error('POST /submit-onboarding failed', error);
+        return res.status(500).json({ success: false, message: error.message });
+    }
+});
+
+router.get('/admin/tenant-onboarding-config', verifyToken, requireAdmin, async (req, res) => {
+    try {
+        const { TenantOnboardingConfig } = getModels(req, 'TenantOnboardingConfig');
+        const doc = await TenantOnboardingConfig.findOne({ configKey: 'default' }).lean();
+        const config = sanitizeTenantOnboardingConfig(doc || null);
+        return res.json({
+            success: true,
+            data: {
+                config,
+                templateLibrary: TENANT_TEMPLATE_LIBRARY,
+            },
+        });
+    } catch (error) {
+        console.error('GET /admin/tenant-onboarding-config failed', error);
+        return res.status(500).json({ success: false, message: error.message });
+    }
+});
+
+router.put('/admin/tenant-onboarding-config', verifyToken, requireAdmin, async (req, res) => {
+    try {
+        const incoming = req.body?.config;
+        if (!incoming || typeof incoming !== 'object') {
+            return res.status(400).json({ success: false, message: 'config object is required.' });
+        }
+        const config = sanitizeTenantOnboardingConfig(incoming);
+        const { TenantOnboardingConfig } = getModels(req, 'TenantOnboardingConfig');
+        const updatedBy = req.user.globalUserId || req.user.userId || null;
+        const doc = await TenantOnboardingConfig.findOneAndUpdate(
+            { configKey: 'default' },
+            { $set: { steps: config.steps, updatedBy } },
+            { new: true, upsert: true, setDefaultsOnInsert: true }
+        ).lean();
+        return res.json({
+            success: true,
+            data: {
+                config: sanitizeTenantOnboardingConfig(doc || null),
+                updatedAt: doc?.updatedAt || null,
+                templateLibrary: TENANT_TEMPLATE_LIBRARY,
+            },
+        });
+    } catch (error) {
+        console.error('PUT /admin/tenant-onboarding-config failed', error);
+        return res.status(500).json({ success: false, message: error.message });
+    }
+});
 
 router.post("/update-user", verifyToken, async (req, res) => {
     const { User } = getModels(req, 'User');

--- a/backend/schemas/tenantConfig.js
+++ b/backend/schemas/tenantConfig.js
@@ -20,6 +20,7 @@ const tenantConfigSchema = new mongoose.Schema(
   {
     configKey: { type: String, required: true, unique: true, default: 'default' },
     tenants: { type: [tenantEntrySchema], default: [] },
+    onboardingConfig: { type: mongoose.Schema.Types.Mixed, default: null },
     updatedBy: { type: String, default: null },
   },
   { timestamps: true }

--- a/backend/schemas/tenantOnboardingConfig.js
+++ b/backend/schemas/tenantOnboardingConfig.js
@@ -1,0 +1,12 @@
+const mongoose = require('mongoose');
+
+const tenantOnboardingConfigSchema = new mongoose.Schema(
+  {
+    configKey: { type: String, required: true, unique: true, default: 'default' },
+    steps: { type: [mongoose.Schema.Types.Mixed], default: [] },
+    updatedBy: { type: String, default: null },
+  },
+  { timestamps: true }
+);
+
+module.exports = tenantOnboardingConfigSchema;

--- a/backend/schemas/user.js
+++ b/backend/schemas/user.js
@@ -41,6 +41,14 @@ const userSchema = new mongoose.Schema({
         type:String,
         trim:true,
     },
+    onboardingResponses: {
+        type: mongoose.Schema.Types.Mixed,
+        default: {},
+    },
+    onboardingCompletedAt: {
+        type: Date,
+        default: null,
+    },
     onboarded:{
         type: Boolean,
         default:false,

--- a/backend/services/getGlobalModelService.js
+++ b/backend/services/getGlobalModelService.js
@@ -3,6 +3,7 @@ const platformRoleSchema = require('../schemas/platformRole');
 const tenantMembershipSchema = require('../schemas/tenantMembership');
 const globalSessionSchema = require('../schemas/globalSession');
 const tenantConfigSchema = require('../schemas/tenantConfig');
+const tenantOnboardingConfigSchema = require('../schemas/tenantOnboardingConfig');
 
 /**
  * Get models from the global/platform DB (cross-tenant data).
@@ -10,7 +11,7 @@ const tenantConfigSchema = require('../schemas/tenantConfig');
  * Requires req.globalDb to be set (see app.js middleware).
  *
  * @param {object} req - request with req.globalDb
- * @param {...string} names - model names: 'GlobalUser', 'PlatformRole', 'TenantMembership', 'Session', 'TenantConfig'
+ * @param {...string} names - model names: 'GlobalUser', 'PlatformRole', 'TenantMembership', 'Session', 'TenantConfig', 'TenantOnboardingConfig'
  * @returns {object} map of requested models
  */
 const getGlobalModels = (req, ...names) => {
@@ -25,6 +26,7 @@ const getGlobalModels = (req, ...names) => {
         TenantMembership: db.model('TenantMembership', tenantMembershipSchema, 'tenant_memberships'),
         Session: db.model('Session', globalSessionSchema, 'sessions'),
         TenantConfig: db.model('TenantConfig', tenantConfigSchema, 'tenant_config'),
+        TenantOnboardingConfig: db.model('TenantOnboardingConfig', tenantOnboardingConfigSchema, 'tenant_onboarding_configs'),
     };
 
     return names.reduce((acc, name) => {

--- a/backend/services/getModelService.js
+++ b/backend/services/getModelService.js
@@ -29,6 +29,7 @@ const androidTesterSignupSchema = require('../schemas/androidTesterSignup');
 const resourcesConfigSchema = require('../schemas/resources');
 const shuttleConfigSchema = require('../schemas/shuttleConfig');
 const noticeConfigSchema = require('../schemas/noticeConfig');
+const tenantOnboardingConfigSchema = require('../schemas/tenantOnboardingConfig');
 // Study Sessions
 const studySessionSchema = require('../schemas/studySession');
 const availabilityPollSchema = require('../schemas/availabilityPoll');
@@ -127,6 +128,7 @@ const getModels = (req, ...names) => {
         ResourcesConfig: req.db.model('ResourcesConfig', resourcesConfigSchema, 'resourcesConfigs'),
         ShuttleConfig: req.db.model('ShuttleConfig', shuttleConfigSchema, 'shuttleConfigs'),
         NoticeConfig: req.db.model('NoticeConfig', noticeConfigSchema, 'noticeConfigs'),
+        TenantOnboardingConfig: req.db.model('TenantOnboardingConfig', tenantOnboardingConfigSchema, 'tenant_onboarding_configs'),
     };
 
     return names.reduce((acc, name) => {

--- a/backend/services/onboardingConfigService.js
+++ b/backend/services/onboardingConfigService.js
@@ -1,0 +1,253 @@
+const SIGNUP_OPTIONS = ['all', 'email', 'google', 'apple', 'saml'];
+
+const ONBOARDING_STEP_TYPES = [
+  'short_text',
+  'long_text',
+  'number',
+  'single_select',
+  'multi_select',
+  'picture_upload',
+  'template_follow_orgs',
+  'template_add_friends',
+];
+
+const TENANT_TEMPLATE_LIBRARY = [
+  {
+    id: 'template_follow_orgs',
+    label: 'Follow Organizations',
+    description: 'Let users pick campus organizations to follow right away.',
+    step: {
+      id: 'follow-orgs',
+      key: 'follow_orgs',
+      type: 'template_follow_orgs',
+      title: 'Follow organizations you care about',
+      description: 'Select organizations to personalize your feed.',
+      required: false,
+    },
+  },
+  {
+    id: 'template_add_friends',
+    label: 'Add Friends',
+    description: 'Prompt users to send a few initial friend requests.',
+    step: {
+      id: 'add-friends',
+      key: 'add_friends',
+      type: 'template_add_friends',
+      title: 'Connect with friends',
+      description: 'Search for classmates and send friend requests.',
+      required: false,
+    },
+  },
+];
+
+const DEFAULT_PLATFORM_ONBOARDING = {
+  defaults: [
+    {
+      id: 'name',
+      key: 'name',
+      type: 'short_text',
+      title: 'What should we call you?',
+      description: 'This name is shown to other users across Meridian.',
+      placeholder: 'Your display name',
+      required: true,
+    },
+    {
+      id: 'picture',
+      key: 'picture',
+      type: 'picture_upload',
+      title: 'Add a profile picture',
+      description: 'Optional, but helps others recognize you.',
+      required: false,
+    },
+  ],
+  bySignupOption: {
+    all: [],
+    email: [],
+    google: [],
+    apple: [],
+    saml: [],
+  },
+};
+
+function toSlug(value, fallback) {
+  const slug = String(value || '')
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '')
+    .slice(0, 48);
+  return slug || fallback;
+}
+
+function toStepId(rawId, fallback) {
+  const cleaned = String(rawId || '')
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 64);
+  return cleaned || fallback;
+}
+
+function normalizeOptions(rawOptions) {
+  const values = Array.isArray(rawOptions) ? rawOptions : [];
+  const normalized = values
+    .map((entry) => {
+      if (entry == null) return null;
+      if (typeof entry === 'string') {
+        const label = entry.trim();
+        if (!label) return null;
+        return { value: toSlug(label, `option_${Date.now()}`), label };
+      }
+      const label = String(entry.label || entry.value || '').trim();
+      if (!label) return null;
+      const value = toSlug(entry.value || label, `option_${Date.now()}`);
+      return { value, label };
+    })
+    .filter(Boolean);
+
+  const deduped = [];
+  const seen = new Set();
+  normalized.forEach((option) => {
+    if (seen.has(option.value)) return;
+    seen.add(option.value);
+    deduped.push(option);
+  });
+  return deduped.slice(0, 50);
+}
+
+function sanitizeStep(rawStep = {}, options = {}) {
+  const { allowTemplates = true } = options;
+  const fallback = `step_${Date.now().toString(36)}`;
+  const type = ONBOARDING_STEP_TYPES.includes(rawStep.type) ? rawStep.type : 'short_text';
+  const isTemplateType = type === 'template_follow_orgs' || type === 'template_add_friends';
+
+  if (isTemplateType && !allowTemplates) {
+    return null;
+  }
+
+  const key = toSlug(rawStep.key || rawStep.id || rawStep.title, fallback);
+  const title = String(rawStep.title || rawStep.key || 'Untitled step').trim().slice(0, 120);
+  const step = {
+    id: toStepId(rawStep.id, key),
+    key,
+    type,
+    title,
+    description: String(rawStep.description || '').trim().slice(0, 300),
+    placeholder: String(rawStep.placeholder || '').trim().slice(0, 180),
+    required: Boolean(rawStep.required),
+  };
+
+  if (type === 'single_select' || type === 'multi_select') {
+    step.options = normalizeOptions(rawStep.options);
+    if (step.options.length === 0) {
+      return null;
+    }
+    if (type === 'multi_select') {
+      const maxSelections = Number(rawStep.maxSelections);
+      if (Number.isFinite(maxSelections) && maxSelections > 0) {
+        step.maxSelections = Math.min(Math.floor(maxSelections), 20);
+      }
+    }
+  }
+
+  if (isTemplateType) {
+    step.templateKey = type === 'template_follow_orgs' ? 'follow_orgs' : 'add_friends';
+  }
+
+  return step;
+}
+
+function ensureUniqueStepIds(steps = []) {
+  const used = new Set();
+  return steps.map((step) => {
+    let candidate = step.id || step.key || `step_${Date.now().toString(36)}`;
+    let counter = 1;
+    while (used.has(candidate)) {
+      candidate = `${step.id || step.key}-${counter++}`;
+    }
+    used.add(candidate);
+    return { ...step, id: candidate };
+  });
+}
+
+function sanitizePlatformOnboardingConfig(rawConfig = null) {
+  const defaultsRaw = Array.isArray(rawConfig?.defaults) ? rawConfig.defaults : [];
+  const defaults = ensureUniqueStepIds(
+    defaultsRaw
+      .map((step) => sanitizeStep(step, { allowTemplates: false }))
+      .filter(Boolean)
+  );
+
+  const bySignupOption = {};
+  SIGNUP_OPTIONS.forEach((option) => {
+    const rawSteps = Array.isArray(rawConfig?.bySignupOption?.[option]) ? rawConfig.bySignupOption[option] : [];
+    bySignupOption[option] = ensureUniqueStepIds(
+      rawSteps
+        .map((step) => sanitizeStep(step, { allowTemplates: false }))
+        .filter(Boolean)
+    );
+  });
+
+  return { defaults, bySignupOption };
+}
+
+function getPlatformOnboardingConfig(rawConfig = null) {
+  if (!rawConfig || typeof rawConfig !== 'object') {
+    return DEFAULT_PLATFORM_ONBOARDING;
+  }
+  const sanitized = sanitizePlatformOnboardingConfig(rawConfig);
+  const hasAnyConfiguredStep =
+    sanitized.defaults.length > 0 ||
+    SIGNUP_OPTIONS.some((option) => (sanitized.bySignupOption[option] || []).length > 0);
+  if (!hasAnyConfiguredStep) {
+    return DEFAULT_PLATFORM_ONBOARDING;
+  }
+  return sanitized;
+}
+
+function sanitizeTenantOnboardingConfig(rawConfig = null) {
+  const stepsRaw = Array.isArray(rawConfig?.steps) ? rawConfig.steps : [];
+  const steps = ensureUniqueStepIds(
+    stepsRaw
+      .map((step) => sanitizeStep(step, { allowTemplates: true }))
+      .filter(Boolean)
+  );
+  return { steps };
+}
+
+function detectSignupOption(user) {
+  if (!user) return 'email';
+  if (user.googleId) return 'google';
+  if (user.appleId) return 'apple';
+  if (user.samlId || user.samlProvider) return 'saml';
+  return 'email';
+}
+
+function resolveOnboardingSteps(platformConfig, tenantConfig, signupOption = 'email') {
+  const normalizedPlatform = getPlatformOnboardingConfig(platformConfig);
+  const normalizedTenant = sanitizeTenantOnboardingConfig(tenantConfig);
+  const signupKey = SIGNUP_OPTIONS.includes(signupOption) ? signupOption : 'email';
+
+  const merged = [
+    ...(normalizedPlatform.defaults || []),
+    ...(normalizedPlatform.bySignupOption?.all || []),
+    ...(normalizedPlatform.bySignupOption?.[signupKey] || []),
+    ...(normalizedTenant.steps || []),
+  ];
+
+  return ensureUniqueStepIds(merged);
+}
+
+module.exports = {
+  SIGNUP_OPTIONS,
+  ONBOARDING_STEP_TYPES,
+  TENANT_TEMPLATE_LIBRARY,
+  DEFAULT_PLATFORM_ONBOARDING,
+  sanitizeStep,
+  sanitizePlatformOnboardingConfig,
+  getPlatformOnboardingConfig,
+  sanitizeTenantOnboardingConfig,
+  detectSignupOption,
+  resolveOnboardingSteps,
+};

--- a/frontend/src/components/OnboardingBuilder/OnboardingBuilder.jsx
+++ b/frontend/src/components/OnboardingBuilder/OnboardingBuilder.jsx
@@ -1,0 +1,291 @@
+import React from 'react';
+import { Icon } from '@iconify-icon/react/dist/iconify.mjs';
+import './OnboardingBuilder.scss';
+
+const CUSTOM_STEP_TYPES = [
+  { value: 'short_text', label: 'Short text' },
+  { value: 'long_text', label: 'Long text' },
+  { value: 'number', label: 'Number' },
+  { value: 'single_select', label: 'Single select' },
+  { value: 'multi_select', label: 'Multi select' },
+  { value: 'picture_upload', label: 'Picture upload' },
+];
+
+function slugify(value) {
+  const normalized = String(value || '')
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '')
+    .slice(0, 48);
+  return normalized || '';
+}
+
+function makeId() {
+  return `step-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function buildNewStep(type = 'short_text') {
+  const isSelect = type === 'single_select' || type === 'multi_select';
+  return {
+    id: makeId(),
+    key: '',
+    type,
+    title: '',
+    description: '',
+    placeholder: '',
+    required: false,
+    options: isSelect ? [] : undefined,
+  };
+}
+
+function parseOptionsFromText(text) {
+  return String(text || '')
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((label) => ({
+      label,
+      value: slugify(label),
+    }))
+    .filter((entry) => entry.value);
+}
+
+function optionsToTextareaValue(options = []) {
+  return options.map((option) => option.label || option.value).join('\n');
+}
+
+function sanitizeStepBeforeSave(step) {
+  const normalized = {
+    id: step.id || makeId(),
+    key: step.key || '',
+    type: step.type || 'short_text',
+    title: step.title || '',
+    description: step.description || '',
+    placeholder: step.placeholder || '',
+    required: Boolean(step.required),
+  };
+  if (normalized.type === 'single_select' || normalized.type === 'multi_select') {
+    normalized.options = Array.isArray(step.options) ? step.options : [];
+  }
+  return normalized;
+}
+
+function StepCard({
+  step,
+  index,
+  onChange,
+  onDelete,
+  onMoveUp,
+  onMoveDown,
+  allowTemplates,
+}) {
+  const isSelect = step.type === 'single_select' || step.type === 'multi_select';
+  const isTemplate = step.type === 'template_follow_orgs' || step.type === 'template_add_friends';
+
+  return (
+    <div className="onboarding-builder-step-card">
+      <div className="onboarding-builder-step-header">
+        <h4>Step {index + 1}</h4>
+        <div className="onboarding-builder-step-actions">
+          <button type="button" onClick={onMoveUp} aria-label="Move step up">
+            <Icon icon="mdi:arrow-up" />
+          </button>
+          <button type="button" onClick={onMoveDown} aria-label="Move step down">
+            <Icon icon="mdi:arrow-down" />
+          </button>
+          <button type="button" onClick={onDelete} aria-label="Delete step">
+            <Icon icon="mdi:delete-outline" />
+          </button>
+        </div>
+      </div>
+
+      <div className="onboarding-builder-grid">
+        <label>
+          Title
+          <input
+            type="text"
+            value={step.title || ''}
+            placeholder="What should we ask?"
+            onChange={(event) => onChange({ title: event.target.value })}
+          />
+        </label>
+        <label>
+          Key
+          <input
+            type="text"
+            value={step.key || ''}
+            placeholder="interest_area"
+            onChange={(event) => onChange({ key: slugify(event.target.value) })}
+          />
+        </label>
+        <label>
+          Type
+          <select
+            value={step.type || 'short_text'}
+            onChange={(event) => {
+              const nextType = event.target.value;
+              const isNextSelect = nextType === 'single_select' || nextType === 'multi_select';
+              onChange({
+                ...step,
+                type: nextType,
+                options: isNextSelect ? (step.options || []) : undefined,
+              });
+            }}
+            disabled={!allowTemplates && isTemplate}
+          >
+            {CUSTOM_STEP_TYPES.map((fieldType) => (
+              <option key={fieldType.value} value={fieldType.value}>
+                {fieldType.label}
+              </option>
+            ))}
+            {allowTemplates && (
+              <>
+                <option value="template_follow_orgs">Template: Follow organizations</option>
+                <option value="template_add_friends">Template: Add friends</option>
+              </>
+            )}
+          </select>
+        </label>
+        <label>
+          Placeholder
+          <input
+            type="text"
+            value={step.placeholder || ''}
+            placeholder="Optional helper text"
+            onChange={(event) => onChange({ placeholder: event.target.value })}
+            disabled={isTemplate || step.type === 'picture_upload'}
+          />
+        </label>
+      </div>
+
+      <label className="onboarding-builder-description">
+        Description
+        <textarea
+          value={step.description || ''}
+          placeholder="Why are we asking this?"
+          onChange={(event) => onChange({ description: event.target.value })}
+        />
+      </label>
+
+      {isSelect && (
+        <label className="onboarding-builder-description">
+          Options (one per line)
+          <textarea
+            value={optionsToTextareaValue(step.options || [])}
+            placeholder={'Freshman\nSophomore\nJunior\nSenior'}
+            onChange={(event) => {
+              onChange({
+                options: parseOptionsFromText(event.target.value),
+              });
+            }}
+          />
+        </label>
+      )}
+
+      <label className="onboarding-builder-required">
+        <input
+          type="checkbox"
+          checked={Boolean(step.required)}
+          onChange={(event) => onChange({ required: event.target.checked })}
+        />
+        Required
+      </label>
+    </div>
+  );
+}
+
+function StepsEditor({ value = [], onChange, allowTemplates = false }) {
+  const steps = Array.isArray(value) ? value : [];
+
+  const updateStep = (index, patch) => {
+    const next = [...steps];
+    next[index] = sanitizeStepBeforeSave({
+      ...next[index],
+      ...patch,
+    });
+    onChange(next);
+  };
+
+  const removeStep = (index) => {
+    const next = [...steps];
+    next.splice(index, 1);
+    onChange(next);
+  };
+
+  const moveStep = (index, delta) => {
+    const target = index + delta;
+    if (target < 0 || target >= steps.length) return;
+    const next = [...steps];
+    [next[index], next[target]] = [next[target], next[index]];
+    onChange(next);
+  };
+
+  const addStep = (type = 'short_text') => {
+    onChange([...steps, buildNewStep(type)]);
+  };
+
+  return (
+    <div className="onboarding-builder-steps">
+      {steps.map((step, index) => (
+        <StepCard
+          key={step.id || `${index}-${step.key || 'step'}`}
+          step={sanitizeStepBeforeSave(step)}
+          index={index}
+          onChange={(patch) => updateStep(index, patch)}
+          onDelete={() => removeStep(index)}
+          onMoveUp={() => moveStep(index, -1)}
+          onMoveDown={() => moveStep(index, 1)}
+          allowTemplates={allowTemplates}
+        />
+      ))}
+      <button type="button" className="onboarding-builder-add-step" onClick={() => addStep()}>
+        <Icon icon="mdi:plus" />
+        Add step
+      </button>
+    </div>
+  );
+}
+
+function OnboardingBuilder({
+  value = [],
+  onChange,
+  context = 'platform',
+  templateLibrary = [],
+}) {
+  const allowTemplates = context === 'tenant';
+
+  const appendTemplate = (template) => {
+    if (!allowTemplates || !template?.step) return;
+    const next = [
+      ...(Array.isArray(value) ? value : []),
+      {
+        ...sanitizeStepBeforeSave(template.step),
+        id: `${template.step.id || makeId()}-${Date.now().toString(36)}`,
+      },
+    ];
+    onChange(next);
+  };
+
+  return (
+    <div className="onboarding-builder">
+      <StepsEditor value={value} onChange={onChange} allowTemplates={allowTemplates} />
+      {allowTemplates && templateLibrary.length > 0 && (
+        <div className="onboarding-template-grid">
+          {templateLibrary.map((template) => (
+            <div className="onboarding-template-card" key={template.id}>
+              <h4>{template.label}</h4>
+              <p>{template.description}</p>
+              <button type="button" onClick={() => appendTemplate(template)}>
+                <Icon icon="mdi:plus" />
+                Add template
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default OnboardingBuilder;

--- a/frontend/src/components/OnboardingBuilder/OnboardingBuilder.scss
+++ b/frontend/src/components/OnboardingBuilder/OnboardingBuilder.scss
@@ -1,0 +1,219 @@
+.onboarding-builder {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+
+  .onboarding-builder-header {
+    h2 {
+      margin: 0;
+      font-size: 1.05rem;
+      color: #101828;
+    }
+
+    p {
+      margin: 0.4rem 0 0 0;
+      color: #475467;
+      font-size: 0.9rem;
+    }
+  }
+
+  .onboarding-builder-mode-tabs {
+    display: flex;
+    gap: 0.45rem;
+    flex-wrap: wrap;
+
+    button {
+      border: 1px solid #d0d5dd;
+      background: #fff;
+      color: #344054;
+      border-radius: 8px;
+      padding: 0.45rem 0.8rem;
+      font-size: 0.82rem;
+      font-weight: 600;
+      cursor: pointer;
+
+      &.active {
+        border-color: #3b82f6;
+        color: #1d4ed8;
+        background: #eff6ff;
+      }
+    }
+  }
+
+  .onboarding-builder-panel {
+    border: 1px solid #e4e7ec;
+    background: #fff;
+    border-radius: 10px;
+    padding: 0.9rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+
+    .panel-head {
+      display: flex;
+      justify-content: space-between;
+      gap: 0.8rem;
+      align-items: center;
+
+      h3 {
+        margin: 0;
+        font-size: 0.98rem;
+        color: #101828;
+      }
+
+      p {
+        margin: 0;
+        color: #667085;
+        font-size: 0.84rem;
+      }
+
+      button {
+        border: 1px solid #d0d5dd;
+        background: #fff;
+        color: #344054;
+        border-radius: 7px;
+        padding: 0.4rem 0.65rem;
+        font-size: 0.8rem;
+        font-weight: 600;
+        cursor: pointer;
+      }
+    }
+
+    .empty-note {
+      margin: 0;
+      color: #667085;
+      font-size: 0.84rem;
+      border: 1px dashed #d0d5dd;
+      border-radius: 8px;
+      padding: 0.65rem 0.75rem;
+      background: #fcfcfd;
+    }
+  }
+
+  .onboarding-builder-step-card {
+    border: 1px solid #e4e7ec;
+    border-radius: 9px;
+    background: #f9fafb;
+    padding: 0.8rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.65rem;
+
+    .onboarding-builder-step-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 0.8rem;
+
+      h4 {
+        margin: 0;
+        font-size: 0.9rem;
+        color: #101828;
+      }
+    }
+
+    .step-controls {
+      display: flex;
+      gap: 0.35rem;
+
+      button {
+        width: 30px;
+        height: 30px;
+        border: 1px solid #d0d5dd;
+        background: #fff;
+        border-radius: 6px;
+        cursor: pointer;
+        color: #475467;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+    }
+
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 0.55rem;
+
+      label {
+        display: flex;
+        flex-direction: column;
+        gap: 0.25rem;
+        font-size: 0.77rem;
+        color: #475467;
+        font-weight: 600;
+      }
+
+      input,
+      select,
+      textarea {
+        width: 100%;
+        border: 1px solid #d0d5dd;
+        border-radius: 7px;
+        padding: 0.45rem 0.55rem;
+        font-size: 0.84rem;
+        box-sizing: border-box;
+        background: #fff;
+        color: #101828;
+      }
+
+      textarea {
+        min-height: 74px;
+        resize: vertical;
+      }
+
+      .full {
+        grid-column: 1 / -1;
+      }
+
+      .required-row {
+        display: flex;
+        align-items: center;
+        gap: 0.45rem;
+        font-size: 0.8rem;
+        color: #344054;
+        font-weight: 500;
+      }
+    }
+  }
+
+  .template-library {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 0.6rem;
+
+    .template-card {
+      border: 1px solid #e4e7ec;
+      border-radius: 9px;
+      padding: 0.7rem;
+      background: #fff;
+      display: flex;
+      flex-direction: column;
+      gap: 0.45rem;
+
+      h4 {
+        margin: 0;
+        font-size: 0.9rem;
+        color: #101828;
+      }
+
+      p {
+        margin: 0;
+        color: #667085;
+        font-size: 0.82rem;
+      }
+
+      button {
+        margin-top: 0.15rem;
+        border: 1px solid #d0d5dd;
+        background: #f8fafc;
+        color: #344054;
+        border-radius: 7px;
+        padding: 0.4rem 0.6rem;
+        font-size: 0.8rem;
+        font-weight: 600;
+        cursor: pointer;
+      }
+    }
+  }
+}

--- a/frontend/src/pages/Admin/PlatformAdminsPage/PlatformAdminsPage.jsx
+++ b/frontend/src/pages/Admin/PlatformAdminsPage/PlatformAdminsPage.jsx
@@ -2,6 +2,7 @@ import React, { useState, useCallback, useEffect } from 'react';
 import { useFetch, authenticatedRequest } from '../../../hooks/useFetch';
 import { setTenantConfigCache } from '../../../config/tenantRedirect';
 import GradientHeader from '../../../assets/Gradients/ApprovalGrad.png';
+import OnboardingBuilder from '../../../components/OnboardingBuilder/OnboardingBuilder';
 import '../General/General.scss';
 import './PlatformAdminsPage.scss';
 
@@ -13,6 +14,17 @@ function PlatformAdminsPage() {
   const [mutationError, setMutationError] = useState(null);
   const [tenantDrafts, setTenantDrafts] = useState({});
   const [savingTenants, setSavingTenants] = useState(false);
+  const [savingPlatformOnboarding, setSavingPlatformOnboarding] = useState(false);
+  const [platformOnboardingDraft, setPlatformOnboardingDraft] = useState({
+    defaults: [],
+    bySignupOption: {
+      all: [],
+      email: [],
+      google: [],
+      apple: [],
+      saml: [],
+    },
+  });
 
   const { data: listResponse, loading, error: fetchError, refetch } = useFetch('/admin/platform-admins');
   const list = listResponse?.success ? (listResponse.data || []) : [];
@@ -22,7 +34,14 @@ function PlatformAdminsPage() {
     error: tenantConfigFetchError,
     refetch: refetchTenantConfig,
   } = useFetch('/admin/tenant-config');
+  const {
+    data: platformOnboardingResponse,
+    loading: platformOnboardingLoading,
+    error: platformOnboardingFetchError,
+    refetch: refetchPlatformOnboarding,
+  } = useFetch('/admin/platform-onboarding-config');
   const tenantRows = tenantConfigResponse?.success ? (tenantConfigResponse.data?.tenants || []) : [];
+  const signupOptions = platformOnboardingResponse?.data?.meta?.signupOptions || ['all', 'email', 'google', 'apple', 'saml'];
 
   useEffect(() => {
     const nextDrafts = {};
@@ -34,6 +53,21 @@ function PlatformAdminsPage() {
     });
     setTenantDrafts(nextDrafts);
   }, [tenantConfigResponse]);
+
+  useEffect(() => {
+    const incoming = platformOnboardingResponse?.data?.config;
+    if (!incoming) return;
+    setPlatformOnboardingDraft({
+      defaults: Array.isArray(incoming.defaults) ? incoming.defaults : [],
+      bySignupOption: {
+        all: Array.isArray(incoming?.bySignupOption?.all) ? incoming.bySignupOption.all : [],
+        email: Array.isArray(incoming?.bySignupOption?.email) ? incoming.bySignupOption.email : [],
+        google: Array.isArray(incoming?.bySignupOption?.google) ? incoming.bySignupOption.google : [],
+        apple: Array.isArray(incoming?.bySignupOption?.apple) ? incoming.bySignupOption.apple : [],
+        saml: Array.isArray(incoming?.bySignupOption?.saml) ? incoming.bySignupOption.saml : [],
+      },
+    });
+  }, [platformOnboardingResponse]);
 
   const handleAdd = useCallback(async (e) => {
     e.preventDefault();
@@ -130,7 +164,27 @@ function PlatformAdminsPage() {
     }
   }, [refetchTenantConfig, tenantDrafts, tenantRows]);
 
-  const error = fetchError || tenantConfigFetchError || mutationError;
+  const handlePlatformOnboardingSave = useCallback(async () => {
+    setSavingPlatformOnboarding(true);
+    setMutationError(null);
+    const { data, error } = await authenticatedRequest('/admin/platform-onboarding-config', {
+      method: 'PUT',
+      data: { config: platformOnboardingDraft },
+      headers: { 'Content-Type': 'application/json' },
+    });
+    setSavingPlatformOnboarding(false);
+    if (error) {
+      setMutationError(data?.message || error);
+      return;
+    }
+    if (data?.success) {
+      refetchPlatformOnboarding();
+    } else {
+      setMutationError(data?.message || 'Failed to save platform onboarding config');
+    }
+  }, [platformOnboardingDraft, refetchPlatformOnboarding]);
+
+  const error = fetchError || tenantConfigFetchError || platformOnboardingFetchError || mutationError;
 
   return (
     <div className="platform-admins-page general">
@@ -200,6 +254,56 @@ function PlatformAdminsPage() {
               </div>
               <button type="button" onClick={handleTenantConfigSave} disabled={savingTenants}>
                 {savingTenants ? 'Saving…' : 'Save tenant settings'}
+              </button>
+            </>
+          )}
+        </div>
+        <div className="platform-admins-onboarding">
+          <div className="platform-admins-onboarding-header">
+            <h2>Platform onboarding defaults</h2>
+            <p>
+              Configure global onboarding steps and per-signup-journey variants.
+              Tenant-specific steps are added from the Root Dashboard.
+            </p>
+          </div>
+          {platformOnboardingLoading ? (
+            <p>Loading platform onboarding…</p>
+          ) : (
+            <>
+              <div className="platform-onboarding-block">
+                <h3>Default steps for everyone</h3>
+                <OnboardingBuilder
+                  value={platformOnboardingDraft.defaults}
+                  onChange={(nextSteps) =>
+                    setPlatformOnboardingDraft((prev) => ({ ...prev, defaults: nextSteps }))
+                  }
+                  context="platform"
+                />
+              </div>
+              <div className="platform-onboarding-variants">
+                {signupOptions
+                  .filter((option) => option !== 'all')
+                  .map((option) => (
+                    <div key={option} className="platform-onboarding-block">
+                      <h3>{option.toUpperCase()} signup-specific steps</h3>
+                      <OnboardingBuilder
+                        value={platformOnboardingDraft.bySignupOption?.[option] || []}
+                        onChange={(nextSteps) =>
+                          setPlatformOnboardingDraft((prev) => ({
+                            ...prev,
+                            bySignupOption: {
+                              ...(prev.bySignupOption || {}),
+                              [option]: nextSteps,
+                            },
+                          }))
+                        }
+                        context="platform"
+                      />
+                    </div>
+                  ))}
+              </div>
+              <button type="button" onClick={handlePlatformOnboardingSave} disabled={savingPlatformOnboarding}>
+                {savingPlatformOnboarding ? 'Saving…' : 'Save platform onboarding'}
               </button>
             </>
           )}

--- a/frontend/src/pages/Admin/PlatformAdminsPage/PlatformAdminsPage.scss
+++ b/frontend/src/pages/Admin/PlatformAdminsPage/PlatformAdminsPage.scss
@@ -122,6 +122,24 @@
       }
     }
   }
+
+  .platform-admins-onboarding {
+    margin-bottom: 1.5rem;
+    padding: 1rem;
+    background: #f8f9fa;
+    border-radius: 8px;
+    border: 1px solid #e9ecef;
+    .builder-header {
+      margin-bottom: 0.75rem;
+      h2 {
+        margin: 0;
+      }
+      p {
+        margin: 0.35rem 0 0;
+        color: #666;
+      }
+    }
+  }
   .platform-admins-list {
     list-style: none;
     padding: 0;

--- a/frontend/src/pages/OnBoarding/Onboard.jsx
+++ b/frontend/src/pages/OnBoarding/Onboard.jsx
@@ -1,276 +1,472 @@
-import React, { useState, useEffect, useRef, useCallback } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { Icon } from '@iconify-icon/react/dist/iconify.mjs';
+import { useNotification } from '../../NotificationContext';
+import { useError } from '../../ErrorContext';
+import useAuth from '../../hooks/useAuth';
+import {
+    getOnboardingConfig,
+    searchOnboardingProfiles,
+    submitOnboarding,
+} from './OnboardHelpers';
 import './Onboard.scss';
-import PurpleGradient from '../../assets/PurpleGrad.svg';
-import YellowRedGradient from '../../assets/YellowRedGrad.svg';
-import Loader from '../../components/Loader/Loader.jsx';
-import DragList from './DragList/DragList.jsx';
-import useAuth from '../../hooks/useAuth.js';
-import Recommendation from './Recommendation/Recommendation.jsx';
-import { useNavigate, useLocation } from 'react-router-dom';
-import { onboardUser } from './OnboardHelpers.js';
-import { useError } from '../../ErrorContext.js'; 
-import { useNotification } from '../../NotificationContext.js';
-import { checkUsername } from '../../DBInteractions.js';
-import { useCache } from '../../CacheContext.js';
-import { debounce} from '../../Query.js';
-import check from '../../assets/Icons/Check.svg';
-import waiting from '../../assets/Icons/Waiting.svg';
-import error from '../../assets/circle-warning.svg';
-import unavailable from '../../assets/Icons/Circle-X.svg';
-import CardHeader from '../../components/ProfileCard/CardHeader/CardHeader.jsx';
 
-function Onboard(){
+function isValuePresent(value) {
+    if (value == null) return false;
+    if (typeof value === 'string') return value.trim() !== '';
+    if (Array.isArray(value)) return value.length > 0;
+    return true;
+}
+
+function Onboard() {
     const [start, setStart] = useState(false);
-    const [current, setCurrent] = useState(0);
-    const [show, setShow] = useState(0);
-    const [currentTransition, setCurrentTransition] = useState(0);
-    const [containerHeight, setContainerHeight] = useState(175);
+    const [loadingConfig, setLoadingConfig] = useState(true);
+    const [submitting, setSubmitting] = useState(false);
+    const [currentStepIndex, setCurrentStepIndex] = useState(0);
+    const [steps, setSteps] = useState([]);
+    const [responses, setResponses] = useState({});
+    const [pictureFile, setPictureFile] = useState(null);
+    const [orgSearchQuery, setOrgSearchQuery] = useState('');
+    const [friendSearchQuery, setFriendSearchQuery] = useState('');
+    const [orgResults, setOrgResults] = useState([]);
+    const [friendResults, setFriendResults] = useState([]);
+    const [searchLoading, setSearchLoading] = useState({ orgs: false, users: false });
+    const [searchError, setSearchError] = useState('');
+    const [configError, setConfigError] = useState('');
+
     const { isAuthenticated, isAuthenticating, user, validateToken } = useAuth();
-    // const { debounce } = useCache();
     const { addNotification } = useNotification();
-    const [userInfo, setUserInfo] = useState(null);
-    const [name, setName] = useState("");
-    const [username, setUsername] = useState(null);
-    const [initialUsername, setInitialUsername] = useState(null);
-    const [sliderValue, setSliderValue] = useState(2);
-    const [isGoogle, setIsGoogle] = useState(null);
-    const [onboarded, setOnboarded] = useState(false);
-    const [usernameValid, setUsernameValid] = useState(0);
-
-    const navigate = useNavigate();
     const { newError } = useError();
-
-    const [buttonActive, setButtonActive] = useState(true);
-
-    const containerRef = useRef(null);
-    const contentRefs = useRef([]);
-
+    const navigate = useNavigate();
     const location = useLocation();
-    const from = location.state?.from?.pathname || '/room/none';
+    const from = location.state?.from?.pathname || '/events-dashboard';
 
+    useEffect(() => {
+        const timer = setTimeout(() => setStart(true), 200);
+        return () => clearTimeout(timer);
+    }, []);
 
-    const [items, setItems] = useState(["outlets", "classroom type", "printer", "table type", "windows"]);
-    const details = {
-        "outlets": "having outlet access from a majority of seats",
-        "classroom type": "ex: lecture hall, classroom, auditorium",
-        "printer": "having a printer in the room",
-        "table type": "ex: small desks, large tables,",
-    }
+    const onboardingStepKeys = useMemo(() => new Set(steps.map((step) => step.key)), [steps]);
 
-    useEffect(()=>{
-        if (containerRef.current) {
-            setContainerHeight(contentRefs.current[0].clientHeight+10);
+    useEffect(() => {
+        if (isAuthenticating) return;
+        if (!isAuthenticated) {
+            navigate('/login');
+            return;
+        }
+        if (user?.onboarded) {
+            navigate(from, { replace: true });
+        }
+    }, [from, isAuthenticated, isAuthenticating, navigate, user]);
+
+    useEffect(() => {
+        if (!isAuthenticated || !user || user.onboarded) return;
+        let cancelled = false;
+        async function loadConfig() {
+            setLoadingConfig(true);
+            setConfigError('');
+            try {
+                const payload = await getOnboardingConfig();
+                if (cancelled) return;
+                if (!payload?.success) {
+                    throw new Error(payload?.message || 'Failed to load onboarding config');
+                }
+                const nextSteps = Array.isArray(payload?.data?.steps) ? payload.data.steps : [];
+                setSteps(nextSteps);
+                const seededResponses = {};
+                if (user.name) seededResponses.name = user.name;
+                if (user.username) seededResponses.username = user.username;
+                setResponses((prev) => ({ ...seededResponses, ...prev }));
+            } catch (error) {
+                if (cancelled) return;
+                setConfigError(error.message || 'Failed to load onboarding config');
+            } finally {
+                if (!cancelled) {
+                    setLoadingConfig(false);
+                }
+            }
+        }
+        loadConfig();
+        return () => {
+            cancelled = true;
+        };
+    }, [isAuthenticated, user]);
+
+    const currentStep = steps[currentStepIndex] || null;
+
+    const stepErrors = useMemo(() => {
+        if (!currentStep) return [];
+        const errors = [];
+        const value = responses[currentStep.key];
+        if (currentStep.required && !isValuePresent(value) && currentStep.type !== 'picture_upload') {
+            errors.push('This step is required.');
+        }
+        if (currentStep.type === 'single_select' && isValuePresent(value) && typeof value !== 'string') {
+            errors.push('Select one option.');
+        }
+        if (currentStep.type === 'multi_select' && isValuePresent(value) && !Array.isArray(value)) {
+            errors.push('Choose one or more options.');
+        }
+        if (currentStep.type === 'number' && isValuePresent(value)) {
+            const num = Number(value);
+            if (!Number.isFinite(num)) {
+                errors.push('Enter a valid number.');
+            }
+        }
+        return errors;
+    }, [currentStep, responses]);
+
+    const canContinue = useMemo(() => {
+        if (!currentStep) return false;
+        if (stepErrors.length > 0) return false;
+        if (!currentStep.required) return true;
+        if (currentStep.type === 'picture_upload') {
+            return true;
+        }
+        return isValuePresent(responses[currentStep.key]);
+    }, [currentStep, responses, stepErrors]);
+
+    const completedCount = useMemo(() => {
+        return steps.filter((step) => {
+            if (step.type === 'picture_upload') return Boolean(pictureFile) || Boolean(user?.picture);
+            return isValuePresent(responses[step.key]);
+        }).length;
+    }, [steps, responses, pictureFile, user?.picture]);
+
+    const handleResponseChange = useCallback((key, value) => {
+        setResponses((prev) => ({
+            ...prev,
+            [key]: value,
+        }));
+    }, []);
+
+    const handleOptionToggle = useCallback((key, value) => {
+        setResponses((prev) => {
+            const current = Array.isArray(prev[key]) ? prev[key] : [];
+            const has = current.includes(value);
+            return {
+                ...prev,
+                [key]: has ? current.filter((entry) => entry !== value) : [...current, value],
+            };
+        });
+    }, []);
+
+    const searchEntities = useCallback(async (type, query) => {
+        setSearchError('');
+        setSearchLoading((prev) => ({ ...prev, [type]: true }));
+        try {
+            const result = await searchOnboardingProfiles(type, query);
+            if (result?.success) {
+                if (type === 'orgs') {
+                    setOrgResults(Array.isArray(result.data) ? result.data : []);
+                } else {
+                    setFriendResults(Array.isArray(result.data) ? result.data : []);
+                }
+            } else {
+                setSearchError(result?.message || 'Search failed');
+            }
+        } catch (error) {
+            setSearchError(error.message || 'Search failed');
+        } finally {
+            setSearchLoading((prev) => ({ ...prev, [type]: false }));
         }
     }, []);
 
-    const validUsername = async (username) => {
-        if (username === null || username === "") {
-            return;
-        }
-        if (username === initialUsername) {
-            setUsernameValid(1);
-            return;
-        }
-        setUsernameValid(0);
-        try{
-            const response = await checkUsername(username);
-            if(response){
-                setUsernameValid(1);
-            } else {
-                setUsernameValid(2);
+    useEffect(() => {
+        if (!steps.some((step) => step.type === 'template_follow_orgs')) return;
+        const timer = setTimeout(() => {
+            searchEntities('orgs', orgSearchQuery);
+        }, 250);
+        return () => clearTimeout(timer);
+    }, [orgSearchQuery, searchEntities, steps]);
+
+    useEffect(() => {
+        if (!steps.some((step) => step.type === 'template_add_friends')) return;
+        const timer = setTimeout(() => {
+            searchEntities('users', friendSearchQuery);
+        }, 250);
+        return () => clearTimeout(timer);
+    }, [friendSearchQuery, searchEntities, steps]);
+
+    const handleSubmit = useCallback(async () => {
+        if (submitting) return;
+        setSubmitting(true);
+        try {
+            const filteredResponses = Object.keys(responses).reduce((acc, key) => {
+                if (!onboardingStepKeys.has(key)) return acc;
+                const value = responses[key];
+                if (!isValuePresent(value)) return acc;
+                acc[key] = value;
+                return acc;
+            }, {});
+            const result = await submitOnboarding({ responses: filteredResponses, pictureFile });
+            if (!result?.success) {
+                throw new Error(result?.message || 'Failed to complete onboarding');
             }
-        } catch (error){
-            addNotification({title: 'Error checking username', message: error.message, type: 'error'});
+            await validateToken();
+            addNotification({
+                title: 'Onboarding complete',
+                message: 'Your profile has been personalized.',
+                type: 'success',
+            });
+            navigate(from, { replace: true });
+        } catch (error) {
+            newError(error, navigate);
+        } finally {
+            setSubmitting(false);
         }
+    }, [addNotification, from, navigate, newError, onboardingStepKeys, pictureFile, responses, submitting, validateToken]);
+
+    const renderStepContent = () => {
+        if (!currentStep) return null;
+        const value = responses[currentStep.key];
+        if (currentStep.type === 'short_text') {
+            return (
+                <input
+                    type="text"
+                    className="onboard-input"
+                    placeholder={currentStep.placeholder || 'Type your answer'}
+                    value={typeof value === 'string' ? value : ''}
+                    onChange={(event) => handleResponseChange(currentStep.key, event.target.value)}
+                />
+            );
+        }
+        if (currentStep.type === 'long_text') {
+            return (
+                <textarea
+                    className="onboard-input onboard-textarea"
+                    placeholder={currentStep.placeholder || 'Type your answer'}
+                    value={typeof value === 'string' ? value : ''}
+                    onChange={(event) => handleResponseChange(currentStep.key, event.target.value)}
+                />
+            );
+        }
+        if (currentStep.type === 'number') {
+            return (
+                <input
+                    type="number"
+                    className="onboard-input"
+                    placeholder={currentStep.placeholder || 'Enter a number'}
+                    value={value ?? ''}
+                    onChange={(event) => handleResponseChange(currentStep.key, event.target.value)}
+                />
+            );
+        }
+        if (currentStep.type === 'single_select') {
+            return (
+                <div className="onboard-chip-list">
+                    {(currentStep.options || []).map((option) => (
+                        <button
+                            type="button"
+                            key={option.value}
+                            className={`onboard-chip ${value === option.value ? 'selected' : ''}`}
+                            onClick={() => handleResponseChange(currentStep.key, option.value)}
+                        >
+                            {option.label}
+                        </button>
+                    ))}
+                </div>
+            );
+        }
+        if (currentStep.type === 'multi_select') {
+            const selectedValues = Array.isArray(value) ? value : [];
+            return (
+                <div className="onboard-chip-list">
+                    {(currentStep.options || []).map((option) => (
+                        <button
+                            type="button"
+                            key={option.value}
+                            className={`onboard-chip ${selectedValues.includes(option.value) ? 'selected' : ''}`}
+                            onClick={() => handleOptionToggle(currentStep.key, option.value)}
+                        >
+                            {option.label}
+                        </button>
+                    ))}
+                </div>
+            );
+        }
+        if (currentStep.type === 'picture_upload') {
+            return (
+                <div className="onboard-picture-upload">
+                    <label className="onboard-picture-input">
+                        <input
+                            type="file"
+                            accept="image/*"
+                            onChange={(event) => {
+                                const file = event.target.files?.[0] || null;
+                                setPictureFile(file);
+                            }}
+                        />
+                        <span>{pictureFile ? pictureFile.name : 'Choose a profile picture'}</span>
+                    </label>
+                    {(pictureFile || user?.picture) && (
+                        <p className="helper">
+                            {pictureFile ? 'New image selected. It will upload on submit.' : 'Current profile image will be kept.'}
+                        </p>
+                    )}
+                </div>
+            );
+        }
+        if (currentStep.type === 'template_follow_orgs') {
+            const selected = Array.isArray(value) ? value : [];
+            return (
+                <div className="onboard-template-step">
+                    <input
+                        type="text"
+                        className="onboard-input"
+                        placeholder="Search organizations"
+                        value={orgSearchQuery}
+                        onChange={(event) => setOrgSearchQuery(event.target.value)}
+                    />
+                    {searchLoading.orgs && <p className="helper">Searching organizations...</p>}
+                    <div className="onboard-search-list">
+                        {orgResults.map((org) => (
+                            <button
+                                type="button"
+                                key={org._id}
+                                className={`onboard-search-item ${selected.includes(org._id) ? 'selected' : ''}`}
+                                onClick={() => {
+                                    const has = selected.includes(org._id);
+                                    const next = has ? selected.filter((id) => id !== org._id) : [...selected, org._id];
+                                    handleResponseChange(currentStep.key, next);
+                                }}
+                            >
+                                <span className="title">{org.name}</span>
+                                {org.description && <span className="subtitle">{org.description}</span>}
+                            </button>
+                        ))}
+                    </div>
+                </div>
+            );
+        }
+        if (currentStep.type === 'template_add_friends') {
+            const selected = Array.isArray(value) ? value : [];
+            return (
+                <div className="onboard-template-step">
+                    <input
+                        type="text"
+                        className="onboard-input"
+                        placeholder="Search users"
+                        value={friendSearchQuery}
+                        onChange={(event) => setFriendSearchQuery(event.target.value)}
+                    />
+                    {searchLoading.users && <p className="helper">Searching users...</p>}
+                    <div className="onboard-search-list">
+                        {friendResults.map((person) => (
+                            <button
+                                type="button"
+                                key={person._id}
+                                className={`onboard-search-item ${selected.includes(person._id) ? 'selected' : ''}`}
+                                onClick={() => {
+                                    const has = selected.includes(person._id);
+                                    const next = has ? selected.filter((id) => id !== person._id) : [...selected, person._id];
+                                    handleResponseChange(currentStep.key, next);
+                                }}
+                            >
+                                <span className="title">{person.name || person.username}</span>
+                                <span className="subtitle">@{person.username}</span>
+                            </button>
+                        ))}
+                    </div>
+                </div>
+            );
+        }
+        return null;
     };
 
-    const debounced = useCallback(debounce(validUsername, 500),[]);
-
-    useEffect(() => {
-        setTimeout(() => {
-            setStart(true);
-        }, 500);
-    },[]);
-    
-    useEffect(() => {
-        if(isAuthenticating){
-            return;
-        }
-        if (!isAuthenticated) {
-            navigate('/login');
-        } else {
-            if(user){
-                if(user.onboarded && (!onboarded)){
-                    navigate(from, {replace: true});
-                }
-                setUserInfo(user);
-                setIsGoogle(user.googleId);
-                console.log(user);
-                setUsername(user.googleId ? user.username : null);
-                setInitialUsername(user.googleId ? user.username : null);
-                setName(user.name);
-            }
-        }
-    }, [isAuthenticating, isAuthenticated, user]);
-
-    useEffect(() => {
-        if (username === null || username === "") {
-            setUsernameValid(3);
-            return;
-        }
-        if (username === initialUsername) {
-            setUsernameValid(1);
-            return;
-        }
-        setUsernameValid(0);
-        debounced(username);
-    }, [username]);
-
-    useEffect(()=>{
-        if(current === 0){return;}
-        setTimeout(() => {
-            setCurrentTransition(currentTransition+1);
-        }, 500);
-        if (contentRefs.current[current] && current !== 0) {
-            setTimeout(() => {
-                setContainerHeight(contentRefs.current[current].offsetHeight);
-            }, 500);
-            console.log(contentRefs.current[current].offsetHeight);
-            console.log(current);
-        }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [current]);
-
-    async function handleOnboardUser(name, username, items, sliderValue){
-        try{
-            const response = await onboardUser(name, username, items, sliderValue);
-            if(response.success){
-                setOnboarded(true);
-                await validateToken();
-            }
-            
-        } catch (error){
-            newError(error, navigate);
-        }
+    if (isAuthenticating || loadingConfig) {
+        return (
+            <div className={`onboard onboard-v2 ${start ? 'visible' : ''}`}>
+                <div className="onboard-shell">
+                    <p>Loading onboarding...</p>
+                </div>
+            </div>
+        );
     }
 
-    useEffect(()=>{
-        if(show === 0){return;}
-        setTimeout(() => {
-            setCurrent(current+1);
-        }, 500);
-
-        if(current === 3){
-            try{
-                handleOnboardUser(name, username, items, sliderValue);
-            } catch (error){
-                newError(error, navigate);
-            }
-        }
-
-        if(current === 4){
-            navigate(from, {replace: true});
-        }
-
-        setButtonActive(false);
-        setTimeout(() => {
-            setButtonActive(true);
-        }, 1000);
-    }, [show]);
-
-
-    const [viewport, setViewport] = useState("100vh");
-
-    useEffect(() => {
-        setViewport((window.innerHeight) + 'px');
-    },[]);
-
-    if(isAuthenticating || !userInfo){
-        return(
-            <div className="onboard"></div>
-        )
+    if (configError) {
+        return (
+            <div className={`onboard onboard-v2 ${start ? 'visible' : ''}`}>
+                <div className="onboard-shell">
+                    <h2>Unable to load onboarding</h2>
+                    <p>{configError}</p>
+                    <button type="button" onClick={() => navigate('/events-dashboard')}>
+                        Back to dashboard
+                    </button>
+                </div>
+            </div>
+        );
     }
 
-    const handleNameChange = (e) => {
-        setName(e.target.value);
-    }
-
-    const handleUsernameChange = (e) => {
-        setUsername(e.target.value);
+    if (!currentStep) {
+        return (
+            <div className={`onboard onboard-v2 ${start ? 'visible' : ''}`}>
+                <div className="onboard-shell">
+                    <h2>Ready to finish onboarding?</h2>
+                    <p>We’ll personalize your experience with the choices you already made.</p>
+                    <button type="button" onClick={handleSubmit} disabled={submitting}>
+                        {submitting ? 'Finishing...' : 'Finish onboarding'}
+                    </button>
+                </div>
+            </div>
+        );
     }
 
     return (
-        <div className={`onboard ${start ? "visible" : ""}`} style={{height: viewport}}>
-            <img src={YellowRedGradient} alt="" className="yellow-red" />
-            <img src={PurpleGradient} alt="" className="purple" />
+        <div className={`onboard onboard-v2 ${start ? 'visible' : ''}`}>
+            <div className="onboard-shell">
+                <header className="onboard-header">
+                    <p className="kicker">Personalize your account</p>
+                    <h2>{currentStep.title}</h2>
+                    {currentStep.description && <p className="description">{currentStep.description}</p>}
+                </header>
 
-            <div className="content" style={{ height: containerHeight}} ref={containerRef}>
-                <div >
-                    { current === 0 &&
-                        <div className={`content ${show === 1 ? "going": ""}`} ref={el => contentRefs.current[0] = el}>
-                            <Loader/>
-                            <h2>welcome to study compass</h2>
-                            <p>Study Compass is a student-created tool designed to help students find study spaces according to their preferences</p>
-                        </div>
-                    }
-                    { current === 1 &&
-                        <div className={`content ${show === 2 ? "going": ""} ${1 === currentTransition ? "": "beforeOnboard"}`} ref={el => contentRefs.current[1] = el}>
-                            <Loader/>
-                            <h2>what should we call you?</h2>
-                            <p>This is the name you will be visible to other users as (putting you real name here is advised):</p>
-                            <input type="text" value={name} onChange={handleNameChange} className="text-input"/>
-                            { isGoogle && 
-                                <div className="content">
-                                    
-                                    <h2>set your username</h2>
-                                    <p>Since you signed up with Google, we generated a username for you, feel free to change it below:</p>
-                                    <div className="username-input">
-                                        <div className="status">
-                                            { usernameValid === 0 && <div className="checking"><img src={waiting} alt="" /><p>checking username...</p></div>}
-                                            { usernameValid === 1 && <div className="available"><img src={check} alt="" /><p>username is available</p></div>}
-                                            { usernameValid === 2 && <div className="taken"><img src={unavailable} alt="" /><p>username is taken</p></div>}
-                                            { usernameValid === 3 && <div className="invalid"><img src={error} alt="" /><p>invalid username</p></div>}   
-                                        </div>
-                                        <input type="text" value={username} onChange={handleUsernameChange} className="text-input"/>
-                                    </div>
-                                </div>
-                            }
-                        </div>
-                    }
-                    { current === 2  &&
-                        <div className={`content ${show === 3 ? "going": ""} ${2 === currentTransition ? "": "beforeOnboard"}`} ref={el => contentRefs.current[2] = el}>
-                            <h2>rank your classroom preferences</h2>
-                            <p>What features do you find most important in your study spaces? Rank them from top to bottom.</p>
-                            <div className="preference-list">
-                                <p className="most">most important</p>
-                                <DragList items={items} setItems={setItems} details={details}/>
-                                <p className="least">least important</p>
-                            </div>
-                        </div>
-                    }
-                    { current === 3 &&
-                        <div className={`content ${current === 4 ? "going": ""} ${3 === currentTransition ? "": "beforeOnboard"}`} ref={el => contentRefs.current[3] = el}>
-                            <Recommendation sliderValue={sliderValue} setSliderValue={setSliderValue}/>
-                        </div>
-                    }
-                    { current === 4 &&
-                        <div className={`content ${current === 5 ? "going": ""} ${4 === currentTransition ? "": "beforeOnboard"}`} ref={el => contentRefs.current[4] = el}>
-                            <h2>welcome to study compass, <br></br>{userInfo.name}!</h2>
-                            <p>Here's your study compass id, make sure to hold onto it!</p>
-                            <div className="card-container">
-                                <CardHeader userInfo={userInfo} settings={false}/>
-                            </div>
-                        </div>
-                    }
-                </div>  
+                <div className="onboard-progress">
+                    <p>{completedCount} of {steps.length} steps completed</p>
+                    <div className="bar">
+                        <span style={{ width: `${Math.max((completedCount / Math.max(steps.length, 1)) * 100, 8)}%` }} />
+                    </div>
+                </div>
+
+                {renderStepContent()}
+
+                {searchError && <p className="error-text">{searchError}</p>}
+                {stepErrors.length > 0 && <p className="error-text">{stepErrors[0]}</p>}
+
+                <div className="onboard-actions">
+                    <button
+                        type="button"
+                        className="secondary"
+                        onClick={() => setCurrentStepIndex((prev) => Math.max(prev - 1, 0))}
+                        disabled={currentStepIndex === 0}
+                    >
+                        <Icon icon="ep:arrow-left" />
+                        Back
+                    </button>
+                    {currentStepIndex < steps.length - 1 ? (
+                        <button
+                            type="button"
+                            className="primary"
+                            onClick={() => setCurrentStepIndex((prev) => Math.min(prev + 1, steps.length - 1))}
+                            disabled={!canContinue}
+                        >
+                            Next
+                            <Icon icon="ep:arrow-right" />
+                        </button>
+                    ) : (
+                        <button
+                            type="button"
+                            className="primary"
+                            onClick={handleSubmit}
+                            disabled={!canContinue || submitting}
+                        >
+                            {submitting ? 'Saving...' : 'Complete onboarding'}
+                        </button>
+                    )}
+                </div>
             </div>
-            
-                <button className={`${ current !== 1 || (name !== "" && (!isGoogle || usernameValid === 1)) ? buttonActive ? "":"deactivated" : "deactivated"}`} onClick={()=>{setShow(show+1)}}>
-                    {current === 4  ? "finish" : "next"}
-                </button>
-                
         </div>
-    )
+    );
 }
 
 export default Onboard;

--- a/frontend/src/pages/OnBoarding/Onboard.scss
+++ b/frontend/src/pages/OnBoarding/Onboard.scss
@@ -1,326 +1,254 @@
-.onboard{
+.onboard.onboard-v2 {
     position: relative;
-    overflow:hidden;
-    height:100vh;
-    width:100vw;
-    display:flex;
-    align-items: center;
-    justify-content: center ;
-    flex-direction: column;
-    opacity: 0;
-    transition: all 0.5s ease-in-out;
-}
-
-.onboard.visible{
-    opacity:1;
-}
-
-.onboard .content h2{
-    font-family: 'Satoshi';
-    color: var(--text);
-    text-align: center;
-    margin:0;
-}
-
-.onboard .yellow-red{
-    position: absolute;
-    top:0;
-    right:0;
-    pointer-events: none;
-    z-index: -1;
-}
-
-.onboard .purple{
-    position:absolute;
-    bottom:0;
-    left:0;
-    pointer-events: none;
-    z-index: -1;
-}
-
-.onboard .content{
-    position: relative;
-    display:flex;
-    flex-direction: column;
+    min-height: 100vh;
+    width: 100vw;
+    display: flex;
     align-items: center;
     justify-content: center;
-    gap:20px;
-    transition: all 0.5s ease-in-out;
-    max-width: 400px;
-    margin-bottom:10px;
-}
-
-.onboard .content .card-container{
-    position: relative;
-    width:100%;
-}
-
-.onboard .content .card-header::after{
-    transition: all 0.5s;
-    content: '';
-    background-image: radial-gradient( circle farthest-corner at 10% 20%,  #F2374C 17.8%, #F9E298 100.2% );
-    filter: blur(0px);
-    width: 100%;
-    height: 100%;
-    z-index: -1;
-    position: absolute;
-    left: 0;
-    top: 0;
+    background: radial-gradient(circle at top right, #fce7f3, transparent 45%),
+        radial-gradient(circle at bottom left, #dbeafe, transparent 40%),
+        var(--background);
     opacity: 0;
-    filter: blur(20px);
-    opacity: 1;
-}
-
-.onboard .content .text-input{
-    padding:10px 20px;
-    font-family: 'Inter';
-    font-weight:600;
-    color:var(--text);
-    border:none;
-    outline:none;
-    background-color: var(--light);
-    border-radius: 10px;
-    font-size:15px;
-}
-
-.onboard .content .loader{
-    margin-top:10px;
-}
-
-.onboard .content.going{
-    opacity:0;
-}
-
-.onoard .content.gone{
-    position: absolute;
-}
-
-.onboard .content.beforeOnboard{
-    opacity:0;
-}
-
-.onboard .content p{
-    max-width: 400px;
-    margin:0;
-    font-family: 'Inter';
-    font-weight:500;
-    color:var(--text);
-    text-align: center;
-    margin-bottom:10px;
-}
-
-.onboard .content .badge p{
-    margin:0 7px;
-    color:white;    
-    font-family: 'Inter';
-    font-size: 12px;
-    font-weight: 600;
-}
-
-.onboard button{
-    font-family: 'Satoshi';
-    font-size: 15px;
-    outline:none;
-    border-radius: 8px;
-    background-color: var(--red);
-    border:none;
-    padding:5px 20px;
-    margin:10px;
-    color: white;
-    cursor:pointer;
-    transition: all 0.5s;
-}
-
-.onboard .content button:hover{
-    cursor:pointer;
-    filter: brightness(0.9);
-}
-
-.onboard button.deactivated{
-    background-color: var(--lightborder);
-    pointer-events: none;
-}
-
-.onboard .logo{
-    width:50px;
-    height:50px;
-}
-
-.content .slider{
-    background: linear-gradient(to right, #FA756D, #87AFF1);
-    -webkit-appearance: none;
-    appearance: none;
-    height:10px;
-    width:400px;
-    border-radius: 5px;
-    margin:0;
+    transition: opacity 0.35s ease;
+    padding: 1.2rem;
     box-sizing: border-box;
 }
 
-
-.slider::-webkit-slider-thumb {
-    -webkit-appearance: none;
-    appearance: none;
-    width: 15px;
-    height: 15px;
-    border-radius: 50%;
-    background: transparent;
-    cursor: pointer;
+.onboard.onboard-v2.visible {
+    opacity: 1;
 }
 
-.slider::-moz-range-thumb {
-    width: 15px;
-    height: 15px;
-    border-radius: 50%;
-    background: transparent;
-    cursor: pointer;
-    transition: transform 0.2s ease;
-}
-
-.sliderText{
-    font-size:14px;
-}
-
-.sliderContainer{
-    display:flex;
+.onboard-v2 .onboard-shell {
+    width: 100%;
+    max-width: 720px;
+    background: var(--background);
+    border: 1px solid var(--lightborder);
+    border-radius: 18px;
+    box-shadow: var(--shadow);
+    padding: 1.1rem 1.2rem;
+    display: flex;
     flex-direction: column;
-    justify-content: center;
-    align-items: center;
-    /* gap:10px; */
-    width:400px;
+    gap: 0.95rem;
 }
 
-.rangeText{
-    display:flex;
-    justify-content: space-between;
-    width:100%;
+.onboard-v2 .onboard-header .kicker {
+    margin: 0;
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--darkborder);
+    font-weight: 700;
 }
 
-.content .rangeText p{
+.onboard-v2 .onboard-header h2 {
+    margin: 0.15rem 0 0 0;
+    color: var(--text);
     font-family: 'Satoshi';
-    font-size: 16px;
-    font-weight: bold;
-    margin:0;
+    font-size: 1.55rem;
 }
 
-.rangeText .routine{
-    color: var(--red) !important;
+.onboard-v2 .onboard-header .description {
+    margin: 0.35rem 0 0 0;
+    color: var(--darkborder);
+    font-size: 0.95rem;
 }
 
-.rangeText .novelty{
-    color: var(--blue) !important;
-
+.onboard-v2 .onboard-progress {
+    display: flex;
+    flex-direction: column;
+    gap: 0.42rem;
 }
 
-.sliderInput{
-    display:grid;
-    width:100%;
+.onboard-v2 .onboard-progress p {
+    margin: 0;
+    color: var(--darkborder);
+    font-size: 0.86rem;
+    font-weight: 600;
 }
 
-.onboard .thumb{
-    height:15px;
-    width:15px;
-    border-radius:50%;
-    background-color: #D9D9D9;
-    position: absolute;
-    align-self: center;
-    pointer-events: none;
-    transition: left 0.3s ease;
+.onboard-v2 .onboard-progress .bar {
+    width: 100%;
+    height: 10px;
+    border-radius: 999px;
+    background: var(--light);
+    overflow: hidden;
 }
 
-.onboard .username-input{
-    position: relative;
-    display: grid;
-    margin-bottom:10px;
+.onboard-v2 .onboard-progress .bar span {
+    display: block;
+    height: 100%;
+    border-radius: inherit;
+    background: linear-gradient(90deg, #f43f5e, #6366f1);
+    transition: width 0.22s ease;
 }
 
-.onboard .status{
-    position: absolute;
-    bottom: -35px;
-    align-self: center;
-    justify-self: center;
+.onboard-v2 .onboard-input,
+.onboard-v2 .onboard-textarea {
+    width: 100%;
+    border: 1px solid var(--lightborder);
+    background: var(--background);
+    border-radius: 10px;
+    padding: 0.62rem 0.72rem;
+    box-sizing: border-box;
+    color: var(--text);
+    font-size: 0.96rem;
+    font-family: 'Inter';
 }
 
-.onboard .status p{
-    font-size:14px;
-    font-weight: 500;
-    margin-bottom:2px;
+.onboard-v2 .onboard-input:focus,
+.onboard-v2 .onboard-textarea:focus {
+    outline: none;
+    border-color: var(--red);
 }
 
-.onboard .status div{
-    display:flex;
-    gap:8px;
+.onboard-v2 .onboard-textarea {
+    min-height: 120px;
+    resize: vertical;
+}
+
+.onboard-v2 .onboard-chip-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.55rem;
+}
+
+.onboard-v2 .onboard-chip {
+    border: 1px solid var(--lightborder);
+    background: var(--background);
+    color: var(--text);
+    border-radius: 999px;
+    padding: 0.42rem 0.75rem;
+    font-size: 0.86rem;
+    font-weight: 600;
+    cursor: pointer;
+}
+
+.onboard-v2 .onboard-chip.selected {
+    border-color: var(--red);
+    background: rgba(244, 63, 94, 0.1);
+    color: var(--red);
+}
+
+.onboard-v2 .onboard-template-step {
+    display: flex;
+    flex-direction: column;
+    gap: 0.55rem;
+}
+
+.onboard-v2 .onboard-search-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.45rem;
+    max-height: 260px;
+    overflow-y: auto;
+    padding-right: 0.2rem;
+}
+
+.onboard-v2 .onboard-search-item {
+    border: 1px solid var(--lightborder);
+    background: var(--background);
+    border-radius: 10px;
+    padding: 0.56rem 0.66rem;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.15rem;
+    cursor: pointer;
+    text-align: left;
+}
+
+.onboard-v2 .onboard-search-item .title {
+    font-size: 0.9rem;
+    color: var(--text);
+    font-weight: 700;
+}
+
+.onboard-v2 .onboard-search-item .subtitle {
+    font-size: 0.8rem;
+    color: var(--darkborder);
+}
+
+.onboard-v2 .onboard-search-item.selected {
+    border-color: var(--red);
+    background: rgba(244, 63, 94, 0.08);
+}
+
+.onboard-v2 .onboard-picture-input {
+    border: 1px dashed var(--lightborder);
+    border-radius: 10px;
+    padding: 0.75rem;
+    cursor: pointer;
+    display: block;
+}
+
+.onboard-v2 .onboard-picture-input input {
+    display: none;
+}
+
+.onboard-v2 .onboard-picture-input span {
+    color: var(--text);
+    font-size: 0.9rem;
+    font-weight: 600;
+}
+
+.onboard-v2 .helper {
+    margin: 0;
+    font-size: 0.84rem;
+    color: var(--darkborder);
+}
+
+.onboard-v2 .error-text {
+    margin: 0;
+    color: #dc2626;
+    font-size: 0.83rem;
+    font-weight: 600;
+}
+
+.onboard-v2 .onboard-actions {
+    display: flex;
+    justify-content: space-between;
+    gap: 0.62rem;
+}
+
+.onboard-v2 .onboard-actions button {
+    border: 1px solid transparent;
+    border-radius: 10px;
+    padding: 0.52rem 0.95rem;
+    display: inline-flex;
     align-items: center;
+    gap: 0.4rem;
+    font-size: 0.88rem;
+    font-weight: 700;
+    cursor: pointer;
+    transition: filter 0.2s ease, opacity 0.2s ease;
 }
 
-.onboard .status img{
-    width:15px;
-    height:15px;
+.onboard-v2 .onboard-actions button.primary {
+    background: var(--red);
+    color: #fff;
 }
 
-.onboard .checking p{
-    color: var(--yellow) !important;
+.onboard-v2 .onboard-actions button.secondary {
+    border-color: var(--lightborder);
+    background: var(--background);
+    color: var(--text);
 }
 
-.onboard .available p{
-    color: var(--green) !important;
+.onboard-v2 .onboard-actions button:disabled {
+    opacity: 0.55;
+    cursor: not-allowed;
 }
 
-.onboard .taken p{
-    color: var(--red) !important;
-
-}
-
-.onboard .invalid p{
-    color: var(--red) !important;
-}
-
-
-@media (max-width: 1000px) {
-    .onboard .yellow-red,
-    .onboard .purple{
-        height:400px;
-    }
-}
-
-@media (max-width: 500px){
-    .onboard .yellow-red,
-    .onboard .purple{
-        height:300px;
+@media (max-width: 700px) {
+    .onboard-v2 .onboard-shell {
+        padding: 0.9rem;
     }
 
-    .onboard{
-        gap:0px;
+    .onboard-v2 .onboard-header h2 {
+        font-size: 1.3rem;
     }
 
-    .onboard button{
-        margin:0;
-    }
-
-    .onboard .content{
-        margin:15px;
-        gap:10px;
-    }
-
-    .sliderContainer{
-        width:100%;
-    }
-
-    .onboard .slider{
-        width:100%;
-        border-radius: 5px;
-    }
-    
-    .onboard .content h2{
-        font-size:20px;
-    }
-
-    .content p{
-        font-size:16px;
-        max-width: 100%;
-    }
-
-    .onboard .card-container{
-        scale:0.9;
+    .onboard-v2 .onboard-actions {
+        flex-direction: column;
     }
 }

--- a/frontend/src/pages/OnBoarding/OnboardHelpers.js
+++ b/frontend/src/pages/OnBoarding/OnboardHelpers.js
@@ -1,19 +1,31 @@
 import apiRequest from '../../utils/postRequest';
 
-const onboardUser = async (name, username, classroom, recommendation) => {
-    try{
-        let classroomPreferences = "";
-        for(let i = 0; i  < classroom.length ; i++){
-            classroomPreferences += classroom[i][0];
-        }
+const getOnboardingConfig = async () => {
+    return apiRequest('/onboarding-config', null, { method: 'GET' });
+};
 
-        const responseBody = await apiRequest('/update-user', {name, username, classroom : classroomPreferences, recommendation, onboarded : true});
-        console.log(responseBody);
-        return responseBody;
+const searchOnboardingProfiles = async (type, query = '', limit = 12) => {
+    return apiRequest('/onboarding-profile', null, {
+        method: 'GET',
+        params: { type, query, limit },
+    });
+};
 
-    } catch (error){
-        throw(error);
+// Backward-compatible alias for earlier imports.
+const searchOnboardingEntities = searchOnboardingProfiles;
+
+const submitOnboarding = async ({ responses, pictureFile }) => {
+    const body = new FormData();
+    body.append('responses', JSON.stringify(responses || {}));
+    if (pictureFile) {
+        body.append('picture', pictureFile);
     }
-}
+    return apiRequest('/submit-onboarding', body, { method: 'POST' });
+};
 
-export { onboardUser }
+export {
+    getOnboardingConfig,
+    searchOnboardingProfiles,
+    searchOnboardingEntities,
+    submitOnboarding,
+};

--- a/frontend/src/pages/Room/Room.jsx
+++ b/frontend/src/pages/Room/Room.jsx
@@ -130,7 +130,7 @@ function Room() {
         if(isAuthenticating){
             return;
         }
-        if(isAuthenticated){
+        if(isAuthenticated && user){
             if(user.onboarded === false){
                 navigate('/onboard');
             }

--- a/frontend/src/pages/Room/Room1.jsx
+++ b/frontend/src/pages/Room/Room1.jsx
@@ -260,7 +260,8 @@ function Room({hideHeader = false, urlType = 'embedded'}) {
                     // In embedded mode, we can't navigate away, so just return
                     return;
                 } else {
-                    navigate('/events-dashboard');
+                    navigate('/onboard');
+                    return;
                 }
             }
         }

--- a/frontend/src/pages/RootDash/RootDash.jsx
+++ b/frontend/src/pages/RootDash/RootDash.jsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useState } from 'react';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
 import Dashboard from '../../components/Dashboard/Dashboard';
 import RootManagement from './RootManagement/RootManagement';
 import ManageFlow from './ManageFlow/ManageFlow';
@@ -7,6 +7,7 @@ import RSSManagement from './RSSManagement/RSSManagement';
 import RoomManager from './RoomManager/RoomManager';
 import ResourcesManagement from './ResourcesManagement/ResourcesManagement';
 import NoticeManagement from './NoticeManagement/NoticeManagement';
+import TenantOnboarding from './TenantOnboarding/TenantOnboarding';
 // import BadgeManager from './BadgeManager/BadgeManager';
 import eventsLogo from '../../assets/Brand Image/EventsLogo.svg';
 
@@ -42,6 +43,11 @@ function RootDash(){
             label: 'Notice', 
             icon: 'mdi:bullhorn',
             element: <NoticeManagement/>
+        },
+        {
+            label: 'Onboarding',
+            icon: 'mdi:account-wrench',
+            element: <TenantOnboarding/>
         },
     ];
 

--- a/frontend/src/pages/RootDash/RootManagement/RootManagement.jsx
+++ b/frontend/src/pages/RootDash/RootManagement/RootManagement.jsx
@@ -1,10 +1,8 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import './RootManagement.scss';
 import AdminGradient from '../../../assets/Gradients/AdminGrad.png';
 import useAuth from '../../../hooks/useAuth';
-import HeaderContainer from '../../../components/HeaderContainer/HeaderContainer';
 import SiteHealth from '../../Admin/General/SiteHealth/SiteHealth';
-import SimpleAnalyticsChart from '../../../components/Analytics/VisitsChart/SimpleAnalyticsChart';
 import BeaconLogo from '../../../assets/Brand Image/SolutionLogos/Beacon.svg';
 import CompassLogo from '../../../assets/Brand Image/SolutionLogos/Compass.svg';
 import AtlasLogo from '../../../assets/Brand Image/SolutionLogos/Atlas.svg';
@@ -37,6 +35,13 @@ function RootManagement(){
                             <button onClick={()=>navigate('/feature-admin/compass')}>Manage</button>
                         </div>
                     </div>
+                </div>
+                <div className="onboarding-shortcut">
+                    <h2>Onboarding</h2>
+                    <p>Configure tenant-specific onboarding fields, templates, and ordering.</p>
+                    <button type="button" onClick={() => navigate('/root-dashboard?page=6')}>
+                        Open tenant onboarding builder
+                    </button>
                 </div>
                 <SiteHealth />
             </div>

--- a/frontend/src/pages/RootDash/RootManagement/RootManagement.scss
+++ b/frontend/src/pages/RootDash/RootManagement/RootManagement.scss
@@ -61,3 +61,18 @@
         flex-wrap: wrap;
     }
 }
+
+.root-management .tenant-onboarding-launch {
+    margin-top: 0.75rem;
+    display: flex;
+    justify-content: flex-end;
+}
+
+.root-management .tenant-onboarding-launch button {
+    border: 1px solid var(--border);
+    background: var(--background);
+    border-radius: 8px;
+    padding: 8px 12px;
+    cursor: pointer;
+    font-weight: 600;
+}

--- a/frontend/src/pages/RootDash/TenantOnboarding/TenantOnboarding.jsx
+++ b/frontend/src/pages/RootDash/TenantOnboarding/TenantOnboarding.jsx
@@ -1,0 +1,90 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import GradientHeader from '../../../assets/Gradients/ApprovalGrad.png';
+import { useFetch, authenticatedRequest } from '../../../hooks/useFetch';
+import OnboardingBuilder from '../../../components/OnboardingBuilder/OnboardingBuilder';
+import './TenantOnboarding.scss';
+
+function TenantOnboarding() {
+  const [mutationError, setMutationError] = useState(null);
+  const [saveState, setSaveState] = useState({ saving: false, savedAt: null });
+  const [tenantSteps, setTenantSteps] = useState([]);
+
+  const {
+    data: tenantOnboardingResponse,
+    loading: tenantOnboardingLoading,
+    error: tenantOnboardingFetchError,
+    refetch: refetchTenantOnboardingConfig,
+  } = useFetch('/admin/tenant-onboarding-config');
+
+  useEffect(() => {
+    const incoming = tenantOnboardingResponse?.success ? (tenantOnboardingResponse.data?.config?.steps || []) : [];
+    setTenantSteps(Array.isArray(incoming) ? incoming : []);
+  }, [tenantOnboardingResponse]);
+
+  const templateLibrary = useMemo(
+    () => (tenantOnboardingResponse?.success ? (tenantOnboardingResponse.data?.templateLibrary || []) : []),
+    [tenantOnboardingResponse]
+  );
+
+  const saveTenantConfig = useCallback(async () => {
+    setSaveState((prev) => ({ ...prev, saving: true }));
+    setMutationError(null);
+
+    const { data, error } = await authenticatedRequest('/admin/tenant-onboarding-config', {
+      method: 'PUT',
+      data: { config: { steps: tenantSteps } },
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    setSaveState((prev) => ({ ...prev, saving: false }));
+
+    if (error) {
+      setMutationError(data?.message || error);
+      return;
+    }
+
+    if (data?.success) {
+      const nextSteps = data?.data?.config?.steps || [];
+      setTenantSteps(Array.isArray(nextSteps) ? nextSteps : []);
+      setSaveState({ saving: false, savedAt: new Date().toISOString() });
+      refetchTenantOnboardingConfig();
+    } else {
+      setMutationError(data?.message || 'Failed to save tenant onboarding config.');
+    }
+  }, [refetchTenantOnboardingConfig, tenantSteps]);
+
+  const error = tenantOnboardingFetchError || mutationError;
+
+  return (
+    <div className="tenant-onboarding-page general">
+      <img src={GradientHeader} alt="" className="grad" />
+      <div className="simple-header">
+        <h1>Tenant Onboarding</h1>
+        <p className="sub">Configure onboarding fields specific to this tenant from the root dashboard.</p>
+      </div>
+
+      <div className="general-content">
+        {error && <div className="tenant-onboarding-error">{error}</div>}
+        {tenantOnboardingLoading ? (
+          <p>Loading tenant onboarding configuration...</p>
+        ) : (
+          <OnboardingBuilder
+            value={tenantSteps}
+            onChange={setTenantSteps}
+            context="tenant"
+            templateLibrary={templateLibrary}
+          />
+        )}
+
+        <div className="tenant-onboarding-actions">
+          <button type="button" onClick={saveTenantConfig} disabled={saveState.saving || tenantOnboardingLoading}>
+            {saveState.saving ? 'Saving tenant onboarding...' : 'Save tenant onboarding configuration'}
+          </button>
+          {saveState.savedAt && <p>Saved at {new Date(saveState.savedAt).toLocaleTimeString()}.</p>}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default TenantOnboarding;

--- a/frontend/src/pages/RootDash/TenantOnboarding/TenantOnboarding.scss
+++ b/frontend/src/pages/RootDash/TenantOnboarding/TenantOnboarding.scss
@@ -1,0 +1,38 @@
+.tenant-onboarding-page {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+
+  .tenant-onboarding-error {
+    color: var(--error, #c00);
+    margin-bottom: 0.8rem;
+  }
+
+  .tenant-onboarding-actions {
+    margin-top: 1rem;
+    display: flex;
+    align-items: center;
+    gap: 0.8rem;
+
+    button {
+      padding: 0.55rem 1rem;
+      border: none;
+      border-radius: 8px;
+      background: var(--primary, #2563eb);
+      color: #fff;
+      cursor: pointer;
+      font-weight: 600;
+
+      &:disabled {
+        opacity: 0.6;
+        cursor: not-allowed;
+      }
+    }
+
+    p {
+      margin: 0;
+      color: #667085;
+      font-size: 0.86rem;
+    }
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add a configurable onboarding system with two levels:
  - Platform-level defaults (including signup-option-specific variants)
  - Tenant-level onboarding steps managed from Root Dashboard
- Add default seeded platform steps for `name` and `picture`.
- Add tenant template steps for:
  - Follow organizations
  - Add friends
- Replace the old static onboarding wizard with a dynamic flow renderer that resolves steps from platform + tenant config and submits responses.
- Apply template effects during onboarding submit (org follow + friend request creation).

## Backend
- Added onboarding config service with normalization/sanitization/resolution logic.
- Extended global config with platform onboarding storage.
- Added tenant onboarding config model in tenant DB.
- Added/updated APIs:
  - `GET /admin/platform-onboarding-config`
  - `PUT /admin/platform-onboarding-config`
  - `GET /admin/tenant-onboarding-template-library`
  - `GET /admin/tenant-onboarding-config`
  - `PUT /admin/tenant-onboarding-config`
  - `GET /onboarding-config`
  - `GET /onboarding-profile` (org/user search for template steps)
  - `POST /submit-onboarding`
- Added onboarding response fields to user schema.

## Frontend
- Added reusable visual builder component: `OnboardingBuilder`.
- Added platform onboarding builder to Admin → Platform Admins page.
- Added tenant onboarding page under Root Dashboard.
- Added shortcut card in Root dashboard landing panel.
- Replaced `/onboard` page with dynamic onboarding step runner supporting:
  - text, textarea, number
  - single/multi-select
  - picture upload
  - follow orgs/add friends template steps

## Validation
- Frontend build succeeds after changes.
- Targeted backend route-outcome tests pass for auth/user routes.

## Notes
- Existing repository-wide frontend lint warnings remain (pre-existing), but changes compile and targeted tests pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-129a1e68-a557-451e-9446-36486ac9d035"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-129a1e68-a557-451e-9446-36486ac9d035"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

